### PR TITLE
Add CHTC GPU Lab flags to sub files

### DIFF
--- a/docker/hello_gpu/hello_gpu.sub
+++ b/docker/hello_gpu/hello_gpu.sub
@@ -28,5 +28,11 @@ request_gpus = 1
 request_memory = 1GB
 request_disk = 500MB
 
+# Opt in to using CHTC GPU Lab resources
++WantGPULab = true
+# Specify short job type to run more GPUs in parallel
+# Can also request "medium" or "long"
++GPUJobLength = "short"
+
 # Tell HTCondor to run 1 instances of our job:
 queue 1

--- a/docker/pytorch_python/pytorch_cnn.sub
+++ b/docker/pytorch_python/pytorch_cnn.sub
@@ -28,7 +28,7 @@ request_cpus = 1
 request_gpus = 1
 
 # select some memory and disk space
-request_memory = 1GB
+request_memory = 2GB
 request_disk = 500MB
 
 # Opt in to using CHTC GPU Lab resources

--- a/docker/pytorch_python/pytorch_cnn.sub
+++ b/docker/pytorch_python/pytorch_cnn.sub
@@ -20,7 +20,6 @@ transfer_input_files = main.py, MNIST_data.tar.gz
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
-
 # We require a machine with a modern version of the CUDA driver
 Requirements = (Target.CUDADriverVersion >= 10.1)
 
@@ -31,6 +30,12 @@ request_gpus = 1
 # select some memory and disk space
 request_memory = 1GB
 request_disk = 500MB
+
+# Opt in to using CHTC GPU Lab resources
++WantGPULab = true
+# Specify short job type to run more GPUs in parallel
+# Can also request "medium" or "long"
++GPUJobLength = "short"
 
 # Tell HTCondor to run 1 instances of our job:
 queue 1

--- a/docker/pytorch_python/pytorch_cnn.sub
+++ b/docker/pytorch_python/pytorch_cnn.sub
@@ -28,7 +28,7 @@ request_cpus = 1
 request_gpus = 1
 
 # select some memory and disk space
-request_memory = 2GB
+request_memory = 3GB
 request_disk = 500MB
 
 # Opt in to using CHTC GPU Lab resources

--- a/docker/tensorflow_python/test_tensorflow.sub
+++ b/docker/tensorflow_python/test_tensorflow.sub
@@ -28,7 +28,7 @@ request_cpus = 1
 request_gpus = 1
 
 # select some memory and disk space
-request_memory = 1GB
+request_memory = 2GB
 request_disk = 500MB
 
 # Opt in to using CHTC GPU Lab resources

--- a/docker/tensorflow_python/test_tensorflow.sub
+++ b/docker/tensorflow_python/test_tensorflow.sub
@@ -20,7 +20,6 @@ transfer_input_files = test_tensorflow.py
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
-
 # We require a machine with a modern version of the CUDA driver
 Requirements = (Target.CUDADriverVersion >= 10.1)
 
@@ -31,6 +30,12 @@ request_gpus = 1
 # select some memory and disk space
 request_memory = 1GB
 request_disk = 500MB
+
+# Opt in to using CHTC GPU Lab resources
++WantGPULab = true
+# Specify short job type to run more GPUs in parallel
+# Can also request "medium" or "long"
++GPUJobLength = "short"
 
 # Tell HTCondor to run 1 instances of our job:
 queue 1

--- a/docker/tensorflow_python/test_tensorflow.sub
+++ b/docker/tensorflow_python/test_tensorflow.sub
@@ -28,7 +28,7 @@ request_cpus = 1
 request_gpus = 1
 
 # select some memory and disk space
-request_memory = 2GB
+request_memory = 3GB
 request_disk = 500MB
 
 # Opt in to using CHTC GPU Lab resources

--- a/test/submit.sub
+++ b/test/submit.sub
@@ -8,6 +8,9 @@ when_to_transfer_output = ON_EXIT
 requirements = (CUDACapability >= 4)
 request_gpus = 1
 
++WantGPULab = true
++GPUJobLength = "short"
+
 request_cpus = 1
 request_memory = 10MB
 request_disk = 10MB


### PR DESCRIPTION
Closes #5

This adds the new GPU Lab flags to our existing submit file examples:
```
+WantGPULab = true
+GPUJobLength = "short"
```

I confirmed that two of the jobs ran successfully, but the PyTorch and TensorFlow examples were held.  The reason was:
```
Hold reason: Error from slot1_7@gpulab2002.chtc.wisc.edu: Docker job has gone over memory limit of 1024 Mb
```
so I increased their memory request.  I'll confirm they run successfully before we merge.