### PR TITLE
NVIDIA GPU Cloud container example

### DIFF
--- a/docker/pytorch_ngc/README.md
+++ b/docker/pytorch_ngc/README.md
@@ -1,0 +1,47 @@
+### Convolutional Neural Network with PyTorch (Python)
+This example shows how to send training and test data to the compute node along
+with the script. After processing the trained network is returned to the
+submit node.  
+
+### Submit file
+
+Here the submit file stays the same as that in the [Hello\_GPU](../hello_gpu/) example with a few minor tweaks. 
+
+We set the Docker image to version of Pytorch that is build with CUDA. 
+```
+docker_image = pytorch/pytorch:1.1.0-cuda10.0-cudnn7.5-runtime
+```
+
+Also, we need the Python script as well as the data transferred to the compute node. 
+These files are located in the [`shared/pytorch`](../../shared/pytorch) directory
+```
+transfer_input_files = ../../shared/pytorch/main.py, ../../shared/pytorch/MNIST_data.tar.gz
+```
+
+The rest of the submit file remains the same.  We run the submit file with 
+```shell
+condor_submit pytorch_cnn.sub
+```
+
+### Execute script
+The [Execute Shell script](./pytorch_cnn.sh) extracts the data and then calls a
+Python script [main.py](../../shared/pytorch/main.py) that figures out the network weights and saves it to disk.
+Then the Execute script deletes the data directory so that it isn't returned to the submit node. 
+
+```shell
+tar zxf MNIST_data.tar.gz
+python main.py --save-model --epochs 20
+rm -r data
+```
+ 
+### Output 
+We have the CNN Network that was trained returned to us as a file
+[mnist\_cnn.pt](./expected_output/mnist_cnn.pt). The are also some output stats
+on the training and test error in the [output
+files](./expected_output/pytorch_cnn.out.txt).  
+```
+Test set: Average loss: 0.0278, Accuracy: 9909/10000 (99%)
+```
+
+You can see a complete list of files expected in the output in the [expected
+output directory](./expected_output/).

--- a/docker/pytorch_ngc/README.md
+++ b/docker/pytorch_ngc/README.md
@@ -1,47 +1,33 @@
-### Convolutional Neural Network with PyTorch (Python)
-This example shows how to send training and test data to the compute node along
-with the script. After processing the trained network is returned to the
-submit node.  
+## Convolutional Neural Network with PyTorch (NVIDIA GPU Cloud)
+This example shows how to use containers from the [NVIDIA GPU Cloud](https://ngc.nvidia.com/catalog/containers) (NGC) to run GPU jobs.
+It uses PyTorch and is very similar to the [PyTorch Docker example](../pytorch_python) that uses a PyTorch container from DockerHub.
 
 ### Submit file
-
-Here the submit file stays the same as that in the [Hello\_GPU](../hello_gpu/) example with a few minor tweaks. 
-
-We set the Docker image to version of Pytorch that is build with CUDA. 
+The submit file is the same as the DockerHub PyTorch example except we use the container from NGC.
 ```
-docker_image = pytorch/pytorch:1.1.0-cuda10.0-cudnn7.5-runtime
+docker_image = nvcr.io/nvidia/pytorch:19.10-py3
 ```
 
-Also, we need the Python script as well as the data transferred to the compute node. 
-These files are located in the [`shared/pytorch`](../../shared/pytorch) directory
+This example uses version `19.10` of the container.
+The available versions, also known as tags, are listed at the [NGC PyTorch site](https://ngc.nvidia.com/catalog/containers/nvidia:pytorch/tags).
+The NVIDIA [support matrix](https://docs.nvidia.com/deeplearning/frameworks/support-matrix/index.html) shows which versions of PyTorch and other packages are available within each versioned container.
+It also specifies the version of CUDA the container is based on.
+This example uses CUDA 10.1.243, Python 3.6, and PyTorch 1.3.0.
+
+We require a GPU server with a version of CUDA that matches the version used for the container.
+```
+Requirements = (Target.CUDADriverVersion >= 10.1)
+```
+This ensures that the server has a new enough NVIDIA driver to run the container.
+
+The Python script and input data are located in the [`shared/pytorch`](../../shared/pytorch) directory
 ```
 transfer_input_files = ../../shared/pytorch/main.py, ../../shared/pytorch/MNIST_data.tar.gz
 ```
 
-The rest of the submit file remains the same.  We run the submit file with 
+The `pytorch_cnn.sh` executable is the same as the DockerHub PyTorch example.
+
+We run the submit file with 
 ```shell
 condor_submit pytorch_cnn.sub
 ```
-
-### Execute script
-The [Execute Shell script](./pytorch_cnn.sh) extracts the data and then calls a
-Python script [main.py](../../shared/pytorch/main.py) that figures out the network weights and saves it to disk.
-Then the Execute script deletes the data directory so that it isn't returned to the submit node. 
-
-```shell
-tar zxf MNIST_data.tar.gz
-python main.py --save-model --epochs 20
-rm -r data
-```
- 
-### Output 
-We have the CNN Network that was trained returned to us as a file
-[mnist\_cnn.pt](./expected_output/mnist_cnn.pt). The are also some output stats
-on the training and test error in the [output
-files](./expected_output/pytorch_cnn.out.txt).  
-```
-Test set: Average loss: 0.0278, Accuracy: 9909/10000 (99%)
-```
-
-You can see a complete list of files expected in the output in the [expected
-output directory](./expected_output/).

--- a/docker/pytorch_ngc/pytorch_cnn.sh
+++ b/docker/pytorch_ngc/pytorch_cnn.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "Hello CHTC from Job $1 running on `hostname`"
+
+# untar the test and training data
+tar zxf MNIST_data.tar.gz
+
+# run the pytorch model
+python main.py --save-model --epochs 20
+
+# remove the data directory
+rm -r data

--- a/docker/pytorch_ngc/pytorch_cnn.sub
+++ b/docker/pytorch_ngc/pytorch_cnn.sub
@@ -1,9 +1,10 @@
-# pytorch test of convolutional neural network
+# PyTorch test of convolutional neural network
 # Submit file 
 
 # Must set the universe to Docker
 universe = docker
-docker_image = pytorch/pytorch:1.1.0-cuda10.0-cudnn7.5-runtime
+# Use the PyTorch container from the NVIDIA GPU Cloud (NGC)
+docker_image = nvcr.io/nvidia/pytorch:20.06-py3
 
 # set the log, error and output files 
 log = pytorch_cnn.log.txt
@@ -23,7 +24,7 @@ should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
 # We require a machine with a modern version of the CUDA driver
-Requirements = (Target.CUDADriverVersion >= 10.1)
+Requirements = (Target.CUDADriverVersion >= 11.0)
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1
@@ -31,7 +32,7 @@ request_gpus = 1
 
 # select some memory and disk space
 request_memory = 3GB
-request_disk = 5GB
+request_disk = 15GB
 
 # Opt in to using CHTC GPU Lab resources
 +WantGPULab = true

--- a/docker/pytorch_ngc/pytorch_cnn.sub
+++ b/docker/pytorch_ngc/pytorch_cnn.sub
@@ -4,7 +4,7 @@
 # Must set the universe to Docker
 universe = docker
 # Use the PyTorch container from the NVIDIA GPU Cloud (NGC)
-docker_image = nvcr.io/nvidia/pytorch:20.06-py3
+docker_image = nvcr.io/nvidia/pytorch:19.10-py3
 
 # set the log, error and output files 
 log = pytorch_cnn.log.txt
@@ -24,7 +24,7 @@ should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
 # We require a machine with a modern version of the CUDA driver
-Requirements = (Target.CUDADriverVersion >= 11.0)
+Requirements = (Target.CUDADriverVersion >= 10.1)
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1

--- a/docker/pytorch_ngc/pytorch_cnn.sub
+++ b/docker/pytorch_ngc/pytorch_cnn.sub
@@ -1,0 +1,43 @@
+# pytorch test of convolutional neural network
+# Submit file 
+
+# Must set the universe to Docker
+universe = docker
+docker_image = pytorch/pytorch:1.1.0-cuda10.0-cudnn7.5-runtime
+
+# set the log, error and output files 
+log = pytorch_cnn.log.txt
+error = pytorch_cnn.err.txt
+output = pytorch_cnn.out.txt
+
+# set the executable to run
+executable = pytorch_cnn.sh
+arguments = $(Process)
+
+# take our python script to the compute node
+# the script and data are shared by multiple examples and located in a
+# different directory
+transfer_input_files = ../../shared/pytorch/main.py, ../../shared/pytorch/MNIST_data.tar.gz
+
+should_transfer_files = YES
+when_to_transfer_output = ON_EXIT
+
+# We require a machine with a modern version of the CUDA driver
+Requirements = (Target.CUDADriverVersion >= 10.1)
+
+# We must request 1 CPU in addition to 1 GPU
+request_cpus = 1
+request_gpus = 1
+
+# select some memory and disk space
+request_memory = 3GB
+request_disk = 5GB
+
+# Opt in to using CHTC GPU Lab resources
++WantGPULab = true
+# Specify short job type to run more GPUs in parallel
+# Can also request "medium" or "long"
++GPUJobLength = "short"
+
+# Tell HTCondor to run 1 instances of our job:
+queue 1


### PR DESCRIPTION
This example serves as a proof of concept that we can run jobs that use containers from NVIDIA GPU Cloud (#4).  The example uses PyTorch because we already have example scripts and input data for PyTorch.  However, this strongly suggests that we could also run the NGC versions of GROMACS and other containers as well.

One difficulty when testing this is that I initially tried the newest version of the container, `20.06-py3`.  However, it is built upon CUDA 11.0.  Adding a requirement in my submit file for CUDA >= 11.0 did not match any GPU servers.  Is it possible we could actually run this version on our GPU servers?  The NVIDIA requirements state:
> Release 20.06 is based on CUDA <<11.0.167>>, which requires NVIDIA driver release <<450.36>>.However, if you are running on Tesla (for example, T4 or any other Tesla board), you may use NVIDIA driver release 418.xx or 440.30.The CUDA driver's compatibility package only supports particular drivers.

If our servers have NVIDIA driver >= 450.36, they should be able to run the container even without CUDA 11.0 installed.

We can also consider documenting the availability of these NGC containers at the CHTC website.  Or we can curate relevant containers in #4 so that facilitators can direct researchers to NGC if it has a container that may help them.

As a bookkeeping note, this branch is based off `agitter:conda` because I wanted to use the shared PyTorch examples.  After we merge #8 it will be easier to review this.  All the changed files are in `docker/pytorch_ngc`.
