### PR TITLE
chore: Fix typos

### DIFF
--- a/conda/pytorch-1.5/README.md
+++ b/conda/pytorch-1.5/README.md
@@ -9,7 +9,7 @@ See the [CHTC conda guide](https://chtc.cs.wisc.edu/uw-research-computing/conda-
 The PyTorch example uses the MNIST dataset and Python file from the [`shared/pytorch`](../../shared/pytorch) directory.
 
 The submit file includes the requirement `CUDADriverVersion >= 10.2`.
-The verisons of CUDA available on the execute node are not used by PyTorch in this example.
+The versions of CUDA available on the execute node are not used by PyTorch in this example.
 The conda package `cudatoolkit` installs CUDA.
 However, this requirement ensures that the execute node has a new enough NVIDIA driver to run `cudatoolkit` version 10.2.
 

--- a/conda/pytorch-1.5/pytorch_cnn.sub
+++ b/conda/pytorch-1.5/pytorch_cnn.sub
@@ -6,7 +6,7 @@ transfer_input_files = environment.yml, ../../shared/pytorch/main.py, ../../shar
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
-# The conda environment will install cudatoolkit verison 10.2
+# The conda environment will install cudatoolkit version 10.2
 # This requirement ensures the execute node has a new enough driver to run it
 # Reference https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 # The Ampere generation GPUS (e.g. A100) cannot run with CUDA 10.2 so add a

--- a/conda/pytorch-1.9/README.md
+++ b/conda/pytorch-1.9/README.md
@@ -9,7 +9,7 @@ See the [CHTC conda guide](https://chtc.cs.wisc.edu/uw-research-computing/conda-
 The PyTorch example uses the MNIST dataset and Python file from the [`shared/pytorch`](../../shared/pytorch) directory.
 
 The submit file includes the requirement `CUDADriverVersion >= 11.1`.
-The verisons of CUDA available on the execute node are not used by PyTorch in this example.
+The versions of CUDA available on the execute node are not used by PyTorch in this example.
 The conda package `cudatoolkit` installs CUDA.
 However, this requirement ensures that the execute node has a new enough NVIDIA driver to run `cudatoolkit` version 11.1.
 

--- a/conda/pytorch-1.9/pytorch_cnn.sub
+++ b/conda/pytorch-1.9/pytorch_cnn.sub
@@ -6,7 +6,7 @@ transfer_input_files = environment.yml, ../../shared/pytorch/main.py, ../../shar
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
-# The conda environment will install cudatoolkit verison 11.1
+# The conda environment will install cudatoolkit version 11.1
 # This requirement ensures the execute node has a new enough driver to run it
 # Reference https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 require_gpus = (DriverVersion >= 11.1)


### PR DESCRIPTION
* Running `codespell .` on the repository found multiple instances of 'version' being typoed.