### PR TITLE
feat: Add Pixi Apptainer example

### DIFF
--- a/containers/pixi/README.md
+++ b/containers/pixi/README.md
@@ -54,13 +54,13 @@ Build a Docker container image from the `Dockerfile` that installs the Pixi envi
 The default values are those set in the `Dockerfile`.
 
 ```
-docker build --file Dockerfile --platform linux/amd64 --tag ghcr.io/<your github org>/templates-gpu:mnist-gpu-noble-cuda-12.9 .
+docker build --file Dockerfile --platform linux/amd64 --tag ghcr.io/<your github org>/templates-gpus:mnist-gpu-noble-cuda-12.9 .
 ```
 
 and then [authenticate](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry) and publish your built container image to your GitHub container registry
 
 ```
-docker push ghcr.io/<your github org>/templates-gpu:mnist-gpu-noble-cuda-12.9
+docker push ghcr.io/<your github org>/templates-gpus:mnist-gpu-noble-cuda-12.9
 ```
 
 Note that this manual build and publish process is slow.
@@ -87,3 +87,91 @@ cd templates-GPUs/containers/pixi
 condor_submit mnist_gpu_docker.sub
 ```
 
+## Apptainer
+
+### Build Apptainer container image
+
+Build a Apptainer container image (`.sif` format) from the `apptainer.def` that installs the Pixi environment `ENVIRONMENT` and CUDA version `CONDA_OVERRIDE_CUDA`.
+The default values are those set in the `apptainer.def`.
+
+```
+apptainer build mnist-gpu-noble-cuda-12.9.sif apptainer.def
+```
+
+and then [authenticate](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry) and publish your built container image to your GitHub container registry
+
+```
+apptainer push mnist-gpu-noble-cuda-12.9.sif oras://ghcr.io/<your github org>/templates-gpus:apptainer-mnist-gpu-noble-cuda-12.9
+```
+
+Note that this manual build and publish process is slow.
+It is recommended to have this step be done through a [continuous integration and continuous delivery (CI/CD) workflow](https://carpentries-incubator.github.io/reproducible-ml-workflows/pixi-deployment.html#automation-with-github-actions-workflows-1).
+
+### Transferring `.sif` files to HTCondor Execution Points
+
+The transferring of `.sif` files can happen one of two ways.
+Both involve setting the `container` universe in the submission file along with giving an endpoint for the `container_image`.
+
+#### Transferring from CHTC `/staging`
+
+Container `.sif` files on CHTC's `/staging/<username>` storage are cached with [ODSF](https://osg-htc.org/services/osdf), and transferred to HTCondor jobs using the
+
+```
+container_image = osdf:///chtc/staging/<username>/<container image name>.sif
+```
+
+HTCondor submission syntax.
+
+**Example**:
+
+```
+container_image = osdf:///chtc/staging/<user name>/apptainer/mnist-gpu-noble-cuda-12.9-sha-80ec247.sif
+```
+
+> [!TIP]
+> OSDF offers the advantage of [not limiting your jobs to running on locations where `/staging/` is mounted](https://chtc.cs.wisc.edu/uw-research-computing/scaling-htc#3-submitting-jobs-to-run-beyond-chtc).
+
+> [!WARNING]
+> OSDF and Pelican treat all cached files as immutable, so each file placed on `/staging/` should have a unique name, such as including information about the repository's Git commit SHA in the file name
+
+#### Using a remote container registry
+
+If the `.sif` file exists on a Linux container registry then the container `.sif` file can be provided to the `container_image` argument [using the `oras://` prefix](https://htcondor.readthedocs.io/en/latest/users-manual/env-of-job.html#container-universe-jobs).
+
+```
+universe = container
+container_image = oras://<container registry domain>/<account>/<container name>:<tag>
+```
+
+**Example**:
+
+```
+universe = container
+container_image = oras://ghcr.io/<your github org>/templates-gpus:apptainer-mnist-gpu-noble-cuda-12.9
+```
+
+> [!TIP]
+> Using the container registry approach allows the container used to be automatically built and deployed through a [continuous integration and continuous delivery (CI/CD) workflow](https://carpentries-incubator.github.io/reproducible-ml-workflows/pixi-deployment.html#automation-with-github-actions-workflows-1).
+> Use of Git commit SHAs in the container image tag can aid in ensuring the software environment provided by the Apptainer container corresponds to the correct version of the code the user is running.
+> Use of a Linux container registry can also help with distribution of the software environment to collaborators external to CHTC.
+
+### Use
+
+* Log into an HTC submit node
+* Clone this repository
+
+```
+git clone https://github.com/CHTC/templates-GPUs
+```
+
+* Navigate to this directory
+
+```
+cd templates-GPUs/containers/pixi
+```
+
+* Submit the example to HTCondor
+
+```
+condor_submit mnist_gpu_apptainer.sub
+```

--- a/containers/pixi/apptainer.def
+++ b/containers/pixi/apptainer.def
@@ -1,0 +1,62 @@
+Bootstrap: docker
+From: ghcr.io/prefix-dev/pixi:noble
+Stage: build
+
+# %arguments have to be defined at each stage
+%arguments
+    CUDA_VERSION=12.9
+    ENVIRONMENT=default
+
+%files
+./pixi.toml /app/
+./pixi.lock /app/
+./.gitignore /app/
+
+%post
+#!/usr/bin/env bash
+export CONDA_OVERRIDE_CUDA={{ CUDA_VERSION }}
+cd /app/
+pixi info
+pixi install --locked --environment {{ ENVIRONMENT }}
+# Activate ENVIRONMENT at container runtime by using the Pixi environment
+# activation script as the container ENTRYPOINT
+echo "#!/usr/bin/env bash" > /app/entrypoint.sh && \
+pixi shell-hook --environment {{ ENVIRONMENT }} -s bash >> /app/entrypoint.sh && \
+echo 'exec "$@"' >> /app/entrypoint.sh
+
+Bootstrap: docker
+From: ghcr.io/prefix-dev/pixi:noble
+Stage: final
+
+%arguments
+    ENVIRONMENT=default
+
+%files from build
+/app/.pixi/envs/{{ ENVIRONMENT }} /app/.pixi/envs/{{ ENVIRONMENT }}
+/app/pixi.toml /app/pixi.toml
+/app/pixi.lock /app/pixi.lock
+/app/.gitignore /app/.gitignore
+# The ignore files are needed for 'pixi run' to work in the container
+/app/.pixi/.gitignore /app/.pixi/.gitignore
+/app/.pixi/.condapackageignore /app/.pixi/.condapackageignore
+/app/entrypoint.sh /app/entrypoint.sh
+
+%post
+#!/usr/bin/env bash
+cd /app/
+pixi info
+chmod +x /app/entrypoint.sh
+
+%runscript
+#!/usr/bin/env bash
+/app/entrypoint.sh "$@"
+
+%startscript
+#!/usr/bin/env bash
+/app/entrypoint.sh "$@"
+
+%test
+#!/usr/bin/env -S bash -e
+. /app/entrypoint.sh
+pixi info
+pixi list

--- a/containers/pixi/mnist_gpu.sh
+++ b/containers/pixi/mnist_gpu.sh
@@ -13,6 +13,10 @@ echo -e "# Activate Pixi environment\n"
 # instead.
 . <(sed '$d' /app/entrypoint.sh)
 
+# Note: Use of nvidia-smi in Apptainer requires the '--nvccli' option.
+# https://apptainer.org/docs/user/main/gpu.html#nvidia-gpus-cuda-nvidia-container-cli
+# As of 2025-06-12, CHTC supports '--nv' but not '--nvccli' and so 'nvidia-smi'
+# will not be found.
 echo -e "\n# Check to see if the NVIDIA drivers can correctly detect the GPU:\n"
 nvidia-smi
 

--- a/containers/pixi/mnist_gpu_apptainer.sub
+++ b/containers/pixi/mnist_gpu_apptainer.sub
@@ -1,0 +1,60 @@
+# Must set the universe to 'container' to use Apptainer
+universe = container
+# Replace this with whatever container image you build yourself
+container_image = oras://ghcr.io/matthewfeickert/templates-gpus:apptainer-mnist-gpu-noble-cuda-12.9
+
+# set the log, error and output files
+log = mnist_gpu_apptainer_$(Cluster)_$(Process).log.txt
+error = mnist_gpu_apptainer_$(Cluster)_$(Process).err.txt
+output = mnist_gpu_apptainer_$(Cluster)_$(Process).out.txt
+
+# allow for tailing files as updated
+stream_error = true
+stream_output = true
+
+# set the executable to run
+executable = mnist_gpu.sh
+arguments = $(Process)
+
+transfer_input_files = ../../shared/pytorch/main.py, ../../shared/pytorch/MNIST_data.tar.gz
+should_transfer_files = YES
+
+# transfer the serialized trained model back
+transfer_output_files = mnist_cnn.pt
+when_to_transfer_output = ON_EXIT
+
+# Require a machine with a modern version of the CUDA driver
+requirements = (GPUs_DriverVersion >= 12.0)
+
+# We must request 1 CPU in addition to 1 GPU
+request_cpus = 1
+request_gpus = 1
+
+# select some memory and disk space
+# this uses less than the normal Pixi example as the sidecar process mounting
+# the linux container is providing the disk for it
+request_memory = 2GB
+# Apptainer jobs take more disk than Docker jobs for some reason
+request_disk = 7GB
+
++WantGPULab = true
++GPUJobLength = "short"
+
+# Specify the GPU hardware architecture required
+# Check against the CUDA GPU Compute Capability for your software
+# e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
+# The listed 'sm_xy' values show the x.y gpu capability supported
+#
+# Note that given
+# https://github.com/conda-forge/cudnn-feedstock/issues/124
+# there can be segfaults for cudnn>=9.11 on pre-Turing devices (<=sm_70)
+# so use sm_70 as a safer lower bound
+gpus_minimum_capability = 7.0
+
+# Optional: required GPU memory
+gpus_minimum_memory = 2GB
+
+# Tell HTCondor to run 1 instances of our job
+# As the container image is cached at the HTCondor facility, this can be
+# scaled out efficiently across multiple copies of the job if needed
+queue 1


### PR DESCRIPTION
Follow up to PR #38 for Apptainer.

* Add example of using a Pixi environment distributed in an Apptainer container image.
   - Link to 'Reproducible Machine Learning Workflows for Scientists' Carpentries Incubator lesson for CI/CD workflow example.
* Add section on transfer of Apptainer container image (.sif) files.
* Correct repository name typo.
   - `templates-gpu` -> `templates-gpus`