### PR TITLE
feat: Use '%environment' section in Apptainer definition file

### DIFF
--- a/containers/pixi/apptainer.def
+++ b/containers/pixi/apptainer.def
@@ -19,10 +19,12 @@ cd /app/
 pixi info
 pixi install --locked --environment {{ ENVIRONMENT }}
 # Activate ENVIRONMENT at container runtime by using the Pixi environment
-# activation script as the container ENTRYPOINT
+# activation script as the container ENTRYPOINT.
+# The ENTRYPOINT does not contain 'exec "$@"' as Apptainer will source it
+# during the env activation and an 'exec' would replace the process before
+# Apptainer completes setup.
 echo "#!/usr/bin/env bash" > /app/entrypoint.sh && \
-pixi shell-hook --environment {{ ENVIRONMENT }} -s bash >> /app/entrypoint.sh && \
-echo 'exec "$@"' >> /app/entrypoint.sh
+pixi shell-hook --environment {{ ENVIRONMENT }} -s bash >> /app/entrypoint.sh
 
 Bootstrap: docker
 From: ghcr.io/prefix-dev/pixi:noble
@@ -47,16 +49,14 @@ cd /app/
 pixi info
 chmod +x /app/entrypoint.sh
 
-%runscript
-#!/usr/bin/env bash
-/app/entrypoint.sh "$@"
-
-%startscript
-#!/usr/bin/env bash
-/app/entrypoint.sh "$@"
+%environment
+. /app/entrypoint.sh
 
 %test
 #!/usr/bin/env -S bash -e
-. /app/entrypoint.sh
+# Pixi/uv need writable cache directories if there are Python projects in the
+# environment, but during %test the root filesystem may be read-only so point
+# caches to /tmp.
+export XDG_CACHE_HOME=/tmp/.cache
 pixi info
 pixi list


### PR DESCRIPTION
* Use the `%environment` section over `%runscript` and `%startscript` for simplicity in defining the environment that should exist when the activation script has been sourced.
   - c.f. https://apptainer.org/docs/user/main/definition_files.html#environment
* Remove the `exec "$@"` from the entrypoint.sh as this would disallow passing commands directly to the Apptainer container through arguments to `apptainer run` as the `exec` would replace the process before Apptainer completes setup.

(Local) example with this change:

```console
$ apptainer build mnist-gpu-noble-cuda-12.9.sif apptainer.def
...
$ apptainer run --containall --writable-tmpfs --nv ./mnist-gpu-noble-cuda-12.9.sif python -c 'import torch; print(torch); print(torch.cuda.is_available())'
<module 'torch' from '/app/.pixi/envs/default/lib/python3.13/site-packages/torch/__init__.py'>
True
```

https://github.com/CHTC/templates-GPUs/blob/ef2148c1df73684041f6a9b87567e0c618e49279/containers/pixi/README.md?plain=1#L176

is unchanged in execution as well.