### PR TITLE
feat: Update GPU compute capability to non-legacy range

### DIFF
--- a/containers/pixi/mnist_gpu_apptainer.sub
+++ b/containers/pixi/mnist_gpu_apptainer.sub
@@ -45,11 +45,8 @@ request_disk = 7GB
 # e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
 # The listed 'sm_xy' values show the x.y gpu capability supported
 #
-# Note that given
-# https://github.com/conda-forge/cudnn-feedstock/issues/124
-# there can be segfaults for cudnn>=9.11 on pre-Turing devices (<=sm_70)
-# so use sm_70 as a safer lower bound
-gpus_minimum_capability = 7.0
+# c.f. https://github.com/carpentries-incubator/reproducible-ml-workflows/issues/27#issuecomment-3176999061
+gpus_minimum_capability = 7.5
 
 # Optional: required GPU memory
 gpus_minimum_memory = 2GB

--- a/containers/pixi/mnist_gpu_docker.sub
+++ b/containers/pixi/mnist_gpu_docker.sub
@@ -6,9 +6,9 @@ docker_pull_policy = missing
 container_image = docker://ghcr.io/matthewfeickert/templates-gpu:mnist-gpu-noble-cuda-12.9
 
 # set the log, error and output files
-log = mnist_gpu_$(Cluster)_$(Process).log.txt
-error = mnist_gpu_$(Cluster)_$(Process).err.txt
-output = mnist_gpu_$(Cluster)_$(Process).out.txt
+log = mnist_gpu_docker_$(Cluster)_$(Process).log.txt
+error = mnist_gpu_docker_$(Cluster)_$(Process).err.txt
+output = mnist_gpu_docker_$(Cluster)_$(Process).out.txt
 
 # allow for tailing files as updated
 stream_error = true
@@ -46,11 +46,8 @@ request_disk = 2GB
 # e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
 # The listed 'sm_xy' values show the x.y gpu capability supported
 #
-# Note that given
-# https://github.com/conda-forge/cudnn-feedstock/issues/124
-# there can be segfaults for cudnn>=9.11 on pre-Turing devices (<=sm_70)
-# so use sm_70 as a safer lower bound
-gpus_minimum_capability = 7.0
+# c.f. https://github.com/carpentries-incubator/reproducible-ml-workflows/issues/27#issuecomment-3176999061
+gpus_minimum_capability = 7.5
 
 # Optional: required GPU memory
 gpus_minimum_memory = 2GB

--- a/pixi/mnist_gpu.sub
+++ b/pixi/mnist_gpu.sub
@@ -34,11 +34,8 @@ request_disk = 30GB
 # e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
 # The listed 'sm_xy' values show the x.y gpu capability supported
 #
-# Note that given
-# https://github.com/conda-forge/cudnn-feedstock/issues/124
-# there can be segfaults for cudnn>=9.11 on pre-Turing devices (<=sm_70)
-# so use sm_70 as a safer lower bound
-gpus_minimum_capability = 7.0
+# c.f. https://github.com/carpentries-incubator/reproducible-ml-workflows/issues/27#issuecomment-3176999061
+gpus_minimum_capability = 7.5
 
 # Optional: required GPU memory
 gpus_minimum_memory = 2GB


### PR DESCRIPTION
* Update `gpus_minimum_capability` to `7.5` in the HTCondor submit description files to ensure that the GPU compute capability is in the modern / non-legacy range for NVIDIA hardware.
   - c.f. https://developer.nvidia.com/cuda/gpus
   - https://github.com/carpentries-incubator/reproducible-ml-workflows/issues/27#issuecomment-3176999061
* Have the Docker submit description file have log files that are at name parity with Apptainer.

On CHTC, we see that moving from `7.0` to `7.5` has no effect as all the reporting GPUs in the pool already have GPU compute capability `7.5` or greater.

```
condor_status -const 'GPUs > 0' -const 'GPUs_Capability >= 7.0' -const 'GPUs_DriverVersion >= 12.0' -af GPUs_DeviceName GPUs_Capability GPUs_DriverVersion | sort | uniq -c | awk 'BEGIN {print "| Count | GPU Model | Capability | Driver Version |"; print "|-------|-----------|------------|----------------|"} {count=$1; driver=$NF; capability=$(NF-1); $1=""; $NF=""; $(NF-1)=""; gsub(/^[ \t]+|[ \t]+$/, ""); printf "| %5s | %-30s | %s | %s |\n", count, $0, capability, driver}'
```

| Count | GPU Model | Capability | Driver Version |
|-------|-----------|------------|----------------|
|    32 | NVIDIA A100-SXM4-40GB          | 8.0 | 12.8 |
|    46 | NVIDIA A100-SXM4-80GB          | 8.0 | 12.8 |
|     8 | NVIDIA A100-SXM4-80GB MIG 3g.40gb | 8.0 | 12.8 |
|     2 | NVIDIA A40                     | 8.6 | 13.1 |
|     4 | NVIDIA GB10                    | 12.1 | 13.0 |
|    21 | NVIDIA GeForce RTX 2080 Ti     | 7.5 | 12.4 |
|    15 | NVIDIA GeForce RTX 2080 Ti     | 7.5 | 12.8 |
|    17 | NVIDIA H100 80GB HBM3          | 9.0 | 12.8 |
|    39 | NVIDIA H200                    | 9.0 | 12.8 |
|     7 | NVIDIA H200                    | 9.0 | 13.1 |
|     5 | NVIDIA H200 NVL                | 9.0 | 12.8 |
|    79 | NVIDIA L40                     | 8.9 | 12.8 |
|    74 | NVIDIA L40S                    | 8.9 | 12.8 |
|    16 | NVIDIA L40S                    | 8.9 | 13.1 |
|     4 | NVIDIA RTX PRO 6000 Blackwell Server Edition | 12.0 | 13.1 |
|     1 | Quadro RTX 6000                | 7.5 | 12.8 |
|     1 | Quadro RTX 8000                | 7.5 | 12.8 |
|     1 | undefined                      | 7.5 | 12.8 |

---

For the reviewers, PR https://github.com/CHTC/templates-GPUs/pull/43 is currently too big in scope / un-atomic to review currently, so I'm going to break it out across a few smaller and better scoped PRs.