### PR TITLE
fix: Add environment variable guards against batch system defaults

### DIFF
--- a/containers/pixi/Dockerfile
+++ b/containers/pixi/Dockerfile
@@ -12,8 +12,12 @@ COPY . .
 ENV CONDA_OVERRIDE_CUDA=$CUDA_VERSION
 RUN pixi install --locked --environment $ENVIRONMENT
 # Activate ENVIRONMENT at container runtime by using the Pixi environment
-# activation script as the container ENTRYPOINT
+# activation script as the container ENTRYPOINT.
+# Set fallback environmental variables to guard against batch system defaults
 RUN echo "#!/usr/bin/env bash" > /app/entrypoint.sh && \
+    echo 'export USER="${USER:-$(id -u)}"' >> /app/entrypoint.sh && \
+    echo 'export LOGNAME="${LOGNAME:-$USER}"' >> /app/entrypoint.sh && \
+    echo '[ -w "${HOME:-/}" ] || export HOME="$(mktemp -d)"' >> /app/entrypoint.sh && \
     pixi shell-hook --environment $ENVIRONMENT --shell bash >> /app/entrypoint.sh && \
     echo 'exec "$@"' >> /app/entrypoint.sh
 


### PR DESCRIPTION
* CHTC's `container` universe runs Docker containers as the execute node's slot `uid`, which has no `/etc/passwd` entry inside the container, and with a cleaned environment that has no `USER` or `LOGNAME` variables set. If `USER` is not set `torchvision` will raise `OSError: No username set in the environment` at import time.
* Export fallback `USER` and `LOGNAME` (the numeric `uid`) in the `ENTRYPOINT` script and set a writable temporary directory when `HOME` is unset or unwritable.
   - Docker sets `HOME=/` for unknown `uids`.

---

Should go in before PR https://github.com/CHTC/templates-GPUs/pull/43